### PR TITLE
Update download-page_configure.jade

### DIFF
--- a/src/views/pages/download-page/download-page_configure/download-page_configure.jade
+++ b/src/views/pages/download-page/download-page_configure/download-page_configure.jade
@@ -26,7 +26,7 @@
         p.line If you have removed Analyzer service from docker-compose, please skip this info.
     .text.text-container.text-margins
       .code.desktop
-        | mkdir data/elasticsearch
+        | mkdir -p data/elasticsearch
         span.desktop(data-copy='mkdir data/elasticsearch') Copy
       .code.desktop
         | chmod g+rwx data/elasticsearch


### PR DESCRIPTION
`-p` option cretes the whole directory path, otherwise this command doesn't pass since user does not have the existing `data` dir yet.