### PR TITLE
Allow prod redeploy via workflow dispatch

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -25,6 +25,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
It will be convenient to just redeploy prod instance without changes in the codebase in favor of Contentful updates by request.