### PR TITLE
EPMRPP-116322 || Handling image preloading on hover

### DIFF
--- a/src/components/Layout/Footer/Footer.scss
+++ b/src/components/Layout/Footer/Footer.scss
@@ -224,6 +224,15 @@
         background-image: var(--hover-icon);
         content: '';
       }
+
+      &::after {
+        position: absolute;
+        width: 0;
+        height: 0;
+        background-image: var(--hover-icon);
+        overflow: hidden;
+        content: '';
+      }
     }
   }
 

--- a/src/components/Layout/Navigation/NavMenu/SectionList/SectionList.scss
+++ b/src/components/Layout/Navigation/NavMenu/SectionList/SectionList.scss
@@ -56,6 +56,15 @@
   .is-desktop & {
     #{$root}-icon--contentful {
       background-image: var(--icon);
+
+      &::after {
+        position: absolute;
+        width: 0;
+        height: 0;
+        background-image: var(--hover-icon);
+        overflow: hidden;
+        content: '';
+      }
     }
 
     /* stylelint-disable order/order */


### PR DESCRIPTION
## Summary

`Footer` and `SectionItem` were injecting `<link rel="preload">` tags for hover SVG icons via `createPortal`. These icons are referenced only through CSS custom properties, so the browser could not match the preloaded resources to actual usage and emitted ~50 "preloaded but not used" warnings per page. The unused preloads competed for bandwidth with critical resources and triggered an early high-priority fetch that blocked LCP resources.

Removed the `createPortal`-based preload injection from both components. Instead, a zero-size `::after` pseudo-element with `background-image: var(--hover-icon)` is added in CSS — the browser fetches hover icons at low priority during idle time, so they are cached before the user hovers. No blinking on first hover, no JS, no console warnings.


### PR Checklist

* [x] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, `master` for release/hotfix)?
* [x] Have you followed the guidelines in our [Dev Guide](../#readme)
* [x] Have you run prettier (`npm run format`)?
* [x] Have you checked that the build output looks according to design (screen, mobile, desktop) in Figma (`npm run serve`)?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced hover icon behavior in footer navigation links for improved visual feedback
  * Updated hover icon styling in desktop navigation menu components for better user interaction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->