### PR TITLE
 EPMRPP-116884 || Sitemap: Add <lastmod> tag for blog post URLs

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -89,8 +89,32 @@ const config: GatsbyConfig = {
               path
             }
           }
+          allContentfulBlogPost {
+            nodes {
+              slug
+              updatedAt
+            }
+          }
         }`,
-        serialize: ({ path }: { path: string }) => {
+        resolvePages: ({
+          allSitePage: { nodes: pages },
+          allContentfulBlogPost: { nodes: blogPosts },
+        }: {
+          allSitePage: { nodes: { path: string }[] };
+          allContentfulBlogPost: { nodes: { slug: string; updatedAt: string }[] };
+        }) => {
+          const lastmodByPath = blogPosts.reduce<Record<string, string>>((acc, post) => {
+            acc[`/blog/${post.slug}/`] = post.updatedAt;
+
+            return acc;
+          }, {});
+
+          return pages.map(page => ({
+            ...page,
+            lastmod: lastmodByPath[page.path],
+          }));
+        },
+        serialize: ({ path, lastmod }: { path: string; lastmod?: string }) => {
           const fileExtensions = ['.html', '.htm', '.xml', '.pdf', '.jpg', '.png', '.css', '.js'];
           const hasFileExtension = fileExtensions.some(ext => path.endsWith(ext));
           const pathWithSlashEnd = path.endsWith('/') || hasFileExtension ? path : `${path}/`;
@@ -108,6 +132,7 @@ const config: GatsbyConfig = {
             url,
             changefreq: 'weekly',
             priority,
+            ...(lastmod ? { lastmod } : {}),
           };
         },
       },


### PR DESCRIPTION
### PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, `master` for release/hotfix)?
* [ ] Have you followed the guidelines in our [Dev Guide](../#readme)
* [ ] Have you run prettier (`npm run format`)?
* [ ] Have you checked that the build output looks according to design (screen, mobile, desktop) in Figma (`npm run serve`)?

## Visuals

<!-- OPTIONAL
  Provide the visual proof (screenshot/gif/video) of your work
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Updates**
  * Master branch now deploys to AWS Amplify instead of GitHub Pages for production hosting.
  * Added automated redirect validation and deployment workflows.

* **Improvements**
  * Enhanced sitemap generation with lastmod timestamps for blog content.
  * Streamlined redirect configuration system for easier management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->