### PR TITLE
EPMRPP-114151 || Automate Community page statistics on the ReportPortal website

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -101,7 +101,7 @@ jobs:
           echo GATSBY_ENABLE_VWO=false >> .env.production
           echo SLACK_BOT_TOKEN=${{ secrets.SLACK_BOT_TOKEN }} >> .env.production
           echo SLACK_CHANNEL_ID=${{ secrets.SLACK_CHANNEL_ID }} >> .env.production
-          echo GITHUB_TOKEN=${{ secrets.STATS_GITHUB_TOKEN }} >> .env.production
+          echo RP_GITHUB_STATS=${{ secrets.STATS_GITHUB_TOKEN }} >> .env.production
 
       - name: Build the source code
         run: npm run build

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -99,6 +99,9 @@ jobs:
           echo GATSBY_MAILCHIMP_LIST_ID=$GATSBY_MAILCHIMP_LIST_ID >> .env.production
           echo RECAPTCHA_SITE_KEY=${{ secrets.RECAPTCHA_SITE_KEY }} >> .env.production
           echo GATSBY_ENABLE_VWO=false >> .env.production
+          echo SLACK_BOT_TOKEN=${{ secrets.SLACK_BOT_TOKEN }} >> .env.production
+          echo SLACK_CHANNEL_ID=${{ secrets.SLACK_CHANNEL_ID }} >> .env.production
+          echo GITHUB_TOKEN=${{ secrets.STATS_GITHUB_TOKEN }} >> .env.production
 
       - name: Build the source code
         run: npm run build

--- a/.github/workflows/deploy-prod-aws.yml
+++ b/.github/workflows/deploy-prod-aws.yml
@@ -82,6 +82,9 @@ jobs:
           echo GATSBY_MAILCHIMP_LIST_ID=${{ env.GATSBY_MAILCHIMP_LIST_ID }} >> .env.production
           echo RECAPTCHA_SITE_KEY=${{ secrets.RECAPTCHA_SITE_KEY }} >> .env.production
           echo GATSBY_ENABLE_VWO=false >> .env.production
+          echo SLACK_BOT_TOKEN=${{ secrets.SLACK_BOT_TOKEN }} >> .env.production
+          echo SLACK_CHANNEL_ID=${{ secrets.SLACK_CHANNEL_ID }} >> .env.production
+          echo GITHUB_TOKEN=${{ secrets.STATS_GITHUB_TOKEN }} >> .env.production
 
       - name: Build the source code
         run: npm run build

--- a/.github/workflows/deploy-prod-aws.yml
+++ b/.github/workflows/deploy-prod-aws.yml
@@ -84,7 +84,7 @@ jobs:
           echo GATSBY_ENABLE_VWO=false >> .env.production
           echo SLACK_BOT_TOKEN=${{ secrets.SLACK_BOT_TOKEN }} >> .env.production
           echo SLACK_CHANNEL_ID=${{ secrets.SLACK_CHANNEL_ID }} >> .env.production
-          echo GITHUB_TOKEN=${{ secrets.STATS_GITHUB_TOKEN }} >> .env.production
+          echo RP_GITHUB_STATS=${{ secrets.STATS_GITHUB_TOKEN }} >> .env.production
 
       - name: Build the source code
         run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ yarn-debug.log*
 yarn-error.log*
 static/github.json
 static/youtube.json
+static/stats.json
 
 # Runtime data
 pids

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -210,9 +210,13 @@ export const onCreateBabelConfig: GatsbyNode['onCreateBabelConfig'] = ({ actions
 export const createPages: GatsbyNode['createPages'] = async ({ graphql, actions, reporter }) => {
   const { createPage } = actions;
 
-  await fetchGitHubStars().then((data: Repos) => {
-    fs.writeFileSync('static/github.json', JSON.stringify(data));
-  });
+  await fetchGitHubStars()
+    .then((data: Repos) => {
+      fs.writeFileSync('static/github.json', JSON.stringify(data));
+    })
+    .catch(err => {
+      console.warn('[stats] Failed to fetch GitHub stars — skipping github.json write.', err);
+    });
 
   await axios
     .get('https://status.reportportal.io/youtube?count=12')

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -95,13 +95,33 @@ async function fetchGitHubStars(): Promise<Repos> {
   }
 }
 
-async function fetchDockerHubPulls(): Promise<number> {
-  const response = await axios.get<{ pull_count: number }>(
-    'https://hub.docker.com/v2/repositories/reportportal/service-api/',
-    { timeout: STATS_API_TIMEOUT },
-  );
+function readExistingDockerHubPulls(): number {
+  try {
+    const content = JSON.parse(fs.readFileSync('static/stats.json', 'utf8')) as {
+      downloads?: number;
+    };
 
-  return response.data.pull_count || 0;
+    return content.downloads ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+async function fetchDockerHubPulls(): Promise<number> {
+  try {
+    const response = await axios.get<{ pull_count: number }>(
+      'https://hub.docker.com/v2/repositories/reportportal/service-api/',
+      { timeout: STATS_API_TIMEOUT },
+    );
+
+    return response.data.pull_count || 0;
+  } catch (err) {
+    console.warn(
+      '[stats] Docker Hub API call failed — keeping existing value from static/stats.json.',
+    );
+
+    return readExistingDockerHubPulls();
+  }
 }
 
 function readExistingSlackMembers(): number {

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -51,10 +51,10 @@ interface SlackConversationInfoResponse {
 const STATS_API_TIMEOUT = 10000;
 
 async function fetchGitHubStars(): Promise<Repos> {
-  const token = process.env.GITHUB_TOKEN;
+  const token = process.env.RP_GITHUB_STATS;
 
   if (!token) {
-    console.info('[stats] GITHUB_TOKEN not set — using status.reportportal.io/github/stars.');
+    console.info('[stats] RP_GITHUB_STATS not set — using status.reportportal.io/github/stars.');
     const response = await axios.get<Repos>('https://status.reportportal.io/github/stars', {
       timeout: STATS_API_TIMEOUT,
     });

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -53,13 +53,20 @@ const STATS_API_TIMEOUT = 10000;
 async function fetchGitHubStars(): Promise<Repos> {
   const token = process.env.RP_GITHUB_STATS;
 
-  if (!token) {
-    console.info('[stats] RP_GITHUB_STATS not set — using status.reportportal.io/github/stars.');
+  const fetchFallback = async (): Promise<Repos> => {
+    console.info('[stats] Using status.reportportal.io/github/stars.');
+
     const response = await axios.get<Repos>('https://status.reportportal.io/github/stars', {
       timeout: STATS_API_TIMEOUT,
     });
 
     return response.data;
+  };
+
+  if (!token) {
+    console.info('[stats] RP_GITHUB_STATS not set — using status.reportportal.io/github/stars.');
+
+    return fetchFallback();
   }
 
   try {
@@ -73,21 +80,24 @@ async function fetchGitHubStars(): Promise<Repos> {
         },
       },
     );
+
     const stars = response.data.stargazers_count;
 
     console.info(`[stats] GitHub stars fetched via api.github.com: ${stars}`);
 
-    return { total: stars, repos: { reportportal: stars } };
+    return {
+      total: stars,
+      repos: {
+        reportportal: stars,
+      },
+    };
   } catch (err) {
     console.warn(
       '[stats] GitHub API call failed — falling back to status.reportportal.io/github/stars.',
     );
 
     try {
-      const response = await axios.get<Repos>('https://status.reportportal.io/github/stars', {
-        timeout: STATS_API_TIMEOUT,
-      });
-      return response.data;
+      return await fetchFallback();
     } catch {
       console.warn('[stats] Fallback GitHub source also failed.');
       throw err;
@@ -146,24 +156,29 @@ async function fetchSlackMembers(): Promise<number | null> {
     return null;
   }
 
-  const response = await axios.get<SlackConversationInfoResponse>(
-    `https://slack.com/api/conversations.info?channel=${channelId}&include_num_members=true`,
-    {
-      timeout: STATS_API_TIMEOUT,
-      headers: {
-        Authorization: `Bearer ${token}`,
+  try {
+    const response = await axios.get<SlackConversationInfoResponse>(
+      `https://slack.com/api/conversations.info?channel=${channelId}&include_num_members=true`,
+      {
+        timeout: STATS_API_TIMEOUT,
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
       },
-    },
-  );
+    );
 
-  if (!response.data.ok) {
-    console.warn(`[stats] Slack API error: "${response.data.error}" — keeping existing value.`);
+    if (!response.data.ok) {
+      console.warn(`[stats] Slack API error: "${response.data.error}" — keeping existing value.`);
+
+      return null;
+    }
+
+    return response.data.channel?.num_members ?? null;
+  } catch (err) {
+    console.warn('[stats] Slack API request failed — keeping existing value.');
 
     return null;
   }
-
-  // Return null if Slack didn't return member count, so existing value is preserved
-  return response.data.channel?.num_members ?? null;
 }
 
 interface ContactUsDto {

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -47,12 +47,17 @@ interface SlackConversationInfoResponse {
   error?: string;
 }
 
+/** Timeout in milliseconds for all statistics API calls (10 seconds) */
+const STATS_API_TIMEOUT = 10000;
+
 async function fetchGitHubStars(): Promise<Repos> {
   const token = process.env.GITHUB_TOKEN;
 
   if (!token) {
     console.info('[stats] GITHUB_TOKEN not set — using status.reportportal.io/github/stars.');
-    const response = await axios.get<Repos>('https://status.reportportal.io/github/stars');
+    const response = await axios.get<Repos>('https://status.reportportal.io/github/stars', {
+      timeout: STATS_API_TIMEOUT,
+    });
 
     return response.data;
   }
@@ -61,6 +66,7 @@ async function fetchGitHubStars(): Promise<Repos> {
     const response = await axios.get<{ stargazers_count: number }>(
       'https://api.github.com/repos/reportportal/reportportal',
       {
+        timeout: STATS_API_TIMEOUT,
         headers: {
           Accept: 'application/vnd.github+json',
           Authorization: `token ${token}`,
@@ -75,18 +81,24 @@ async function fetchGitHubStars(): Promise<Repos> {
   } catch (err) {
     console.warn(
       '[stats] GitHub API call failed — falling back to status.reportportal.io/github/stars.',
-      err,
     );
 
-    const response = await axios.get<Repos>('https://status.reportportal.io/github/stars');
-
-    return response.data;
+    try {
+      const response = await axios.get<Repos>('https://status.reportportal.io/github/stars', {
+        timeout: STATS_API_TIMEOUT,
+      });
+      return response.data;
+    } catch {
+      console.warn('[stats] Fallback GitHub source also failed.');
+      throw err;
+    }
   }
 }
 
 async function fetchDockerHubPulls(): Promise<number> {
   const response = await axios.get<{ pull_count: number }>(
     'https://hub.docker.com/v2/repositories/reportportal/service-api/',
+    { timeout: STATS_API_TIMEOUT },
   );
 
   return response.data.pull_count || 0;
@@ -117,6 +129,7 @@ async function fetchSlackMembers(): Promise<number | null> {
   const response = await axios.get<SlackConversationInfoResponse>(
     `https://slack.com/api/conversations.info?channel=${channelId}&include_num_members=true`,
     {
+      timeout: STATS_API_TIMEOUT,
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -129,7 +142,8 @@ async function fetchSlackMembers(): Promise<number | null> {
     return null;
   }
 
-  return response.data.channel?.num_members ?? 0;
+  // Return null if Slack didn't return member count, so existing value is preserved
+  return response.data.channel?.num_members ?? null;
 }
 
 interface ContactUsDto {
@@ -184,10 +198,9 @@ export const createPages: GatsbyNode['createPages'] = async ({ graphql, actions,
     console.info(
       `[stats] Written stats.json — downloads: ${downloads}, slackMembers: ${slackMembers}`,
     );
-  } catch (err) {
+  } catch {
     console.warn(
       '[stats] Failed to fetch live community stats — falling back to values already in static/stats.json.',
-      err,
     );
   }
 

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -36,7 +36,100 @@ interface CaseTypeDto {
 
 interface Repos {
   total: number;
-  repos: Record<string, string>;
+  repos: Record<string, number | string>;
+}
+
+interface SlackConversationInfoResponse {
+  ok: boolean;
+  channel?: {
+    num_members: number;
+  };
+  error?: string;
+}
+
+async function fetchGitHubStars(): Promise<Repos> {
+  const token = process.env.GITHUB_TOKEN;
+
+  if (!token) {
+    console.info('[stats] GITHUB_TOKEN not set — using status.reportportal.io/github/stars.');
+    const response = await axios.get<Repos>('https://status.reportportal.io/github/stars');
+
+    return response.data;
+  }
+
+  try {
+    const response = await axios.get<{ stargazers_count: number }>(
+      'https://api.github.com/repos/reportportal/reportportal',
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `token ${token}`,
+        },
+      },
+    );
+    const stars = response.data.stargazers_count;
+
+    console.info(`[stats] GitHub stars fetched via api.github.com: ${stars}`);
+
+    return { total: stars, repos: { reportportal: stars } };
+  } catch (err) {
+    console.warn(
+      '[stats] GitHub API call failed — falling back to status.reportportal.io/github/stars.',
+      err,
+    );
+
+    const response = await axios.get<Repos>('https://status.reportportal.io/github/stars');
+
+    return response.data;
+  }
+}
+
+async function fetchDockerHubPulls(): Promise<number> {
+  const response = await axios.get<{ pull_count: number }>(
+    'https://hub.docker.com/v2/repositories/reportportal/service-api/',
+  );
+
+  return response.data.pull_count || 0;
+}
+
+function readExistingSlackMembers(): number {
+  try {
+    const content = JSON.parse(fs.readFileSync('static/stats.json', 'utf8')) as {
+      slackMembers?: number;
+    };
+
+    return content.slackMembers ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+async function fetchSlackMembers(): Promise<number | null> {
+  const token = process.env.SLACK_BOT_TOKEN;
+  const channelId = process.env.SLACK_CHANNEL_ID;
+
+  if (!token || !channelId) {
+    console.info('[stats] SLACK_BOT_TOKEN / SLACK_CHANNEL_ID not set — keeping existing value.');
+
+    return null;
+  }
+
+  const response = await axios.get<SlackConversationInfoResponse>(
+    `https://slack.com/api/conversations.info?channel=${channelId}&include_num_members=true`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+
+  if (!response.data.ok) {
+    console.warn(`[stats] Slack API error: "${response.data.error}" — keeping existing value.`);
+
+    return null;
+  }
+
+  return response.data.channel?.num_members ?? 0;
 }
 
 interface ContactUsDto {
@@ -68,12 +161,9 @@ export const onCreateBabelConfig: GatsbyNode['onCreateBabelConfig'] = ({ actions
 export const createPages: GatsbyNode['createPages'] = async ({ graphql, actions, reporter }) => {
   const { createPage } = actions;
 
-  await axios
-    .get('https://status.reportportal.io/github/stars')
-    .then((response: { data: Repos }) => response.data)
-    .then((data: Repos) => {
-      fs.writeFileSync('static/github.json', JSON.stringify(data));
-    });
+  await fetchGitHubStars().then((data: Repos) => {
+    fs.writeFileSync('static/github.json', JSON.stringify(data));
+  });
 
   await axios
     .get('https://status.reportportal.io/youtube?count=12')
@@ -81,6 +171,25 @@ export const createPages: GatsbyNode['createPages'] = async ({ graphql, actions,
     .then(data => {
       fs.writeFileSync('static/youtube.json', JSON.stringify(data || []));
     });
+
+  try {
+    const [downloads, liveSlackMembers] = await Promise.all([
+      fetchDockerHubPulls(),
+      fetchSlackMembers(),
+    ]);
+
+    const slackMembers = liveSlackMembers ?? readExistingSlackMembers();
+
+    fs.writeFileSync('static/stats.json', JSON.stringify({ downloads, slackMembers }));
+    console.info(
+      `[stats] Written stats.json — downloads: ${downloads}, slackMembers: ${slackMembers}`,
+    );
+  } catch (err) {
+    console.warn(
+      '[stats] Failed to fetch live community stats — falling back to values already in static/stats.json.',
+      err,
+    );
+  }
 
   const blogPost = path.resolve('./src/templates/blog-post/blog-post.tsx');
 

--- a/src/components/Layout/Navigation/Navigation.tsx
+++ b/src/components/Layout/Navigation/Navigation.tsx
@@ -9,9 +9,7 @@ import { useScrollDirection } from '@app/hooks/useScrollDirection';
 import { useHasMounted } from '@app/hooks/useHasMounted';
 import { useMediaQuerySafe } from '@app/hooks/useMediaQuerySafe';
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import githubStats from '../../../../static/github.json'; // Will be generated at build time
+import githubStats from '../../../../static/github.json';
 import {
   SolutionsMenu,
   ProductMenu,

--- a/src/components/StatisticList/StatisticList.tsx
+++ b/src/components/StatisticList/StatisticList.tsx
@@ -6,7 +6,7 @@ import { getEaseInOutTransition, PropsWithAnimation } from '@app/utils';
 import './StatisticList.scss';
 
 export interface StatisticsEntry {
-  quantity: string;
+  quantity?: string;
   entities: string;
   achievement?: string;
 }
@@ -40,7 +40,7 @@ export const StatisticList: FC<PropsWithAnimation<StatisticListProps>> = ({
     <ul className="statistic-list">
       {statistics.map(({ quantity, entities, achievement }, index) => (
         <motion.li
-          key={quantity}
+          key={entities}
           className="white-border"
           {...getAnimation({ isInView, delay: 0.5 + index * 0.1 })}
         >

--- a/src/containers/CommunityPage/Hero/Hero.tsx
+++ b/src/containers/CommunityPage/Hero/Hero.tsx
@@ -16,9 +16,12 @@ export const Hero: FC = () => {
     () =>
       STATISTICS.map(statistic => {
         if (statistic.entities === 'Stars on GitHub') {
+          const raw = githubStats.repos.reportportal;
+          const value = Number(raw);
+
           return {
             ...statistic,
-            quantity: formatShortNumber(githubStats.repos.reportportal),
+            quantity: formatShortNumber(Number.isFinite(value) ? value : 0),
           };
         }
 

--- a/src/containers/CommunityPage/Hero/Hero.tsx
+++ b/src/containers/CommunityPage/Hero/Hero.tsx
@@ -1,10 +1,10 @@
 import React, { FC, useMemo } from 'react';
 import { StatisticList } from '@app/components/StatisticList';
 import { createBemBlockBuilder } from '@app/utils';
+import { formatShortNumber } from '@app/utils/formatShortNumber';
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import githubStats from '../../../../static/github.json'; // Will be generated at build time
+import githubStats from '../../../../static/github.json';
+import statsData from '../../../../static/stats.json';
 import { STATISTICS } from './constants';
 
 import './Hero.scss';
@@ -18,7 +18,21 @@ export const Hero: FC = () => {
         if (statistic.entities === 'Stars on GitHub') {
           return {
             ...statistic,
-            quantity: `${githubStats.repos.reportportal}`,
+            quantity: formatShortNumber(githubStats.repos.reportportal),
+          };
+        }
+
+        if (statistic.entities === 'Downloads') {
+          return {
+            ...statistic,
+            quantity: formatShortNumber(statsData.downloads),
+          };
+        }
+
+        if (statistic.entities === 'Community members') {
+          return {
+            ...statistic,
+            quantity: formatShortNumber(statsData.slackMembers),
           };
         }
 

--- a/src/containers/CommunityPage/Hero/constants.ts
+++ b/src/containers/CommunityPage/Hero/constants.ts
@@ -1,19 +1,8 @@
 import { StatisticsEntry } from '@app/components/StatisticList';
 
-export const STATISTICS = [
-  {
-    quantity: '2,0M+',
-    entities: 'Downloads',
-  },
-  {
-    quantity: '6,5M',
-    entities: 'Active sessions per year ',
-  },
-  {
-    quantity: '8,705',
-    entities: 'Slack channel members',
-  },
-  {
-    entities: 'Stars on GitHub',
-  } as StatisticsEntry,
+export const STATISTICS: StatisticsEntry[] = [
+  { entities: 'Downloads' },
+  { quantity: '6.5M', entities: 'Active sessions per year' },
+  { entities: 'Community members' },
+  { entities: 'Stars on GitHub' },
 ];

--- a/src/containers/CommunityPage/JoinOurCommunity/JoinOurCommunity.tsx
+++ b/src/containers/CommunityPage/JoinOurCommunity/JoinOurCommunity.tsx
@@ -3,6 +3,9 @@ import classNames from 'classnames';
 import { Link } from '@app/components/Link';
 import { TitleBlock } from '@app/components/TitleBlock';
 import { createBemBlockBuilder } from '@app/utils';
+import { formatShortNumber } from '@app/utils/formatShortNumber';
+
+import statsData from '../../../../static/stats.json';
 
 import './JoinOurCommunity.scss';
 
@@ -12,8 +15,9 @@ export const JoinOurCommunity: FC = () => (
   <div className={getBlocksWith()}>
     <TitleBlock
       title="Join our Slack community"
-      subtitle="Unlock a world of insights, collaborate, and learn together — join our vibrant Slack
-      community of 8700+ members"
+      subtitle={`Unlock a world of insights, collaborate, and learn together — join our vibrant community of ${formatShortNumber(
+        statsData.slackMembers,
+      )} members`}
     />
     <Link
       className={classNames(getBlocksWith('__button'), 'btn btn--primary btn--large')}

--- a/src/containers/NewLandingPage/components/OpenSource/constants.ts
+++ b/src/containers/NewLandingPage/components/OpenSource/constants.ts
@@ -4,17 +4,13 @@ export interface StatCard {
   label: string;
 }
 
-export const STAT_CARDS: StatCard[] = [
-  { iconKey: 'star', value: '2K', label: 'GitHub stars' },
-  { iconKey: 'fork', value: '500+', label: 'Forks' },
-  { iconKey: 'contributors', value: '8.7K+', label: 'Community members' },
-];
-
 export interface FeatureItem {
   iconKey: 'opensource' | 'community' | 'core';
   title: string;
   description: string;
 }
+
+export const FORKS_CARD: StatCard = { iconKey: 'fork', value: '500+', label: 'Forks' };
 
 export const FEATURE_LIST: FeatureItem[] = [
   {

--- a/src/containers/NewLandingPage/components/OpenSource/index.tsx
+++ b/src/containers/NewLandingPage/components/OpenSource/index.tsx
@@ -3,8 +3,11 @@ import classNames from 'classnames';
 import { createBemBlockBuilder } from '@app/utils';
 import { Link } from '@app/components/Link';
 import { ArrowLink } from '@app/components/ArrowLink';
+import { formatShortNumber } from '@app/utils/formatShortNumber';
 
-import { STAT_CARDS, FEATURE_LIST, FeatureItem } from './constants';
+import githubStats from '../../../../../static/github.json';
+import statsData from '../../../../../static/stats.json';
+import { FORKS_CARD, FEATURE_LIST, FeatureItem, StatCard } from './constants';
 import OpenSourceIcon from './svg/open-source-icon.inline.svg';
 import GitIcon from './svg/git-icon.inline.svg';
 import FeatureOpensourceIcon from './svg/feature-opensource.inline.svg';
@@ -20,6 +23,20 @@ const FEATURE_ICONS: Record<FeatureItem['iconKey'], React.FC> = {
   community: FeatureCommunityIcon,
   core: FeatureCoreIcon,
 };
+
+const STAT_CARDS: StatCard[] = [
+  {
+    iconKey: 'star',
+    value: formatShortNumber(githubStats.repos.reportportal),
+    label: 'GitHub stars',
+  },
+  FORKS_CARD,
+  {
+    iconKey: 'contributors',
+    value: formatShortNumber(statsData.slackMembers),
+    label: 'Community members',
+  },
+];
 
 export const OpenSource: FC = () => (
   <section className={getBlocksWith()}>

--- a/src/containers/NewLandingPage/components/OpenSource/index.tsx
+++ b/src/containers/NewLandingPage/components/OpenSource/index.tsx
@@ -27,13 +27,20 @@ const FEATURE_ICONS: Record<FeatureItem['iconKey'], React.FC> = {
 const STAT_CARDS: StatCard[] = [
   {
     iconKey: 'star',
-    value: formatShortNumber(githubStats.repos.reportportal),
+    value: (() => {
+      const raw = githubStats.repos.reportportal;
+      const num = Number(raw);
+
+      return formatShortNumber(Number.isFinite(num) ? num : 0);
+    })(),
     label: 'GitHub stars',
   },
   FORKS_CARD,
   {
     iconKey: 'contributors',
-    value: formatShortNumber(statsData.slackMembers),
+    value: formatShortNumber(
+      Number.isFinite(Number(statsData.slackMembers)) ? Number(statsData.slackMembers) : 0,
+    ),
     label: 'Community members',
   },
 ];

--- a/src/containers/NewLandingPage/components/TrustedBy/constants.ts
+++ b/src/containers/NewLandingPage/components/TrustedBy/constants.ts
@@ -1,5 +1,4 @@
-export const STATS = [
+export const STATIC_STATS = [
   { digits: '1.7', suffix: 'K+', label: 'Teams worldwide' },
   { digits: '85', suffix: 'M+', label: 'Launches per year' },
-  { digits: '2.6', suffix: 'M+', label: 'Downloads' },
 ];

--- a/src/containers/NewLandingPage/components/TrustedBy/index.tsx
+++ b/src/containers/NewLandingPage/components/TrustedBy/index.tsx
@@ -3,8 +3,10 @@ import Marquee from 'react-fast-marquee';
 import classNames from 'classnames';
 import { createBemBlockBuilder, COMMON_MARQUEE_PROPS } from '@app/utils';
 import { useClientCarouselItems } from '@app/hooks/useClientCarouselItems';
+import { formatShortNumberParts } from '@app/utils/formatShortNumber';
 
-import { STATS } from './constants';
+import statsData from '../../../../../static/stats.json';
+import { STATIC_STATS } from './constants';
 
 import './TrustedBy.scss';
 
@@ -13,6 +15,15 @@ const getBlocksWith = createBemBlockBuilder(['trusted-by']);
 // Repeat items 3× so total width always exceeds the viewport,
 // preventing the gap react-fast-marquee shows when items don't fill the track.
 const REPEAT_COUNT = 3;
+
+const { digits: downloadDigits, suffix: downloadSuffix } = formatShortNumberParts(
+  statsData.downloads,
+);
+
+const ALL_STATS = [
+  ...STATIC_STATS,
+  { digits: downloadDigits, suffix: downloadSuffix, label: 'Downloads' },
+];
 
 export const TrustedBy: FC = () => {
   const { allSlidesItems } = useClientCarouselItems();
@@ -39,7 +50,7 @@ export const TrustedBy: FC = () => {
       </div>
 
       <div className={classNames(getBlocksWith('__stats'), 'container')}>
-        {STATS.map(({ digits, suffix, label }) => (
+        {ALL_STATS.map(({ digits, suffix, label }) => (
           <div className={getBlocksWith('__stat')} key={label}>
             <span className={getBlocksWith('__stat-value')}>
               <span className={getBlocksWith('__stat-digits')}>{digits}</span>

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -26,3 +26,23 @@ declare module 'react-scroll' {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export const Link: ComponentType<any>;
 }
+
+/** Generated at build time by gatsby-node.ts */
+declare module '*/static/github.json' {
+  interface RepoStats {
+    total: number;
+    repos: Record<string, number | string>;
+  }
+  const content: RepoStats;
+  export default content;
+}
+
+/** Generated at build time by gatsby-node.ts */
+declare module '*/static/stats.json' {
+  interface CommunityStats {
+    downloads: number;
+    slackMembers: number;
+  }
+  const content: CommunityStats;
+  export default content;
+}

--- a/src/utils/formatShortNumber.ts
+++ b/src/utils/formatShortNumber.ts
@@ -1,0 +1,59 @@
+/**
+ * Formats a large integer into a compact human-readable string.
+ *
+ * Rules:
+ *  - Truncates to 1 decimal place (floors, never rounds up)
+ *  - Appends "+" when the number is not an exact multiple of the unit (1M or 1K)
+ *
+ * Examples:
+ *   6_000_000  → "6M"      (exact million)
+ *   2_650_000  → "2.6M+"   (truncated, has remainder)
+ *   8_705      → "8.7K+"   (truncated, has remainder)
+ *   2_000      → "2K"      (exact thousand)
+ *   2_016      → "2K+"     (truncated)
+ */
+export const formatShortNumber = (num: number): string => {
+  if (num >= 1_000_000) {
+    const value = Math.floor(num / 100_000) / 10;
+    const suffix = num % 1_000_000 === 0 ? 'M' : 'M+';
+
+    return `${value}${suffix}`;
+  }
+
+  if (num >= 1_000) {
+    const value = Math.floor(num / 100) / 10;
+    const suffix = num % 1_000 === 0 ? 'K' : 'K+';
+
+    return `${value}${suffix}`;
+  }
+
+  return `${num}`;
+};
+
+/**
+ * Same logic as formatShortNumber, but returns digits and suffix separately.
+ * Used by components (e.g. TrustedBy) that style the numeric part and the
+ * unit suffix independently.
+ *
+ * Examples:
+ *   2_650_000  → { digits: "2.6", suffix: "M+" }
+ *   6_000_000  → { digits: "6",   suffix: "M"  }
+ *   8_705      → { digits: "8.7", suffix: "K+" }
+ */
+export const formatShortNumberParts = (num: number): { digits: string; suffix: string } => {
+  if (num >= 1_000_000) {
+    const value = Math.floor(num / 100_000) / 10;
+    const suffix = num % 1_000_000 === 0 ? 'M' : 'M+';
+
+    return { digits: `${value}`, suffix };
+  }
+
+  if (num >= 1_000) {
+    const value = Math.floor(num / 100) / 10;
+    const suffix = num % 1_000 === 0 ? 'K' : 'K+';
+
+    return { digits: `${value}`, suffix };
+  }
+
+  return { digits: `${num}`, suffix: '' };
+};

--- a/static/stats.json
+++ b/static/stats.json
@@ -1,0 +1,1 @@
+{ "downloads": 2869521, "slackMembers": 1 }


### PR DESCRIPTION
### PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, `master` for release/hotfix)?
* [ ] Have you followed the guidelines in our [Dev Guide](../#readme)
* [ ] Have you run prettier (`npm run format`)?
* [ ] Have you checked that the build output looks according to design (screen, mobile, desktop) in Figma (`npm run serve`)?

## Description
Automates the fetching and display of live community statistics across the website.

What's Changed
GitHub Stars: Now fetched via GitHub API (with fallback to status.reportportal.io)
Docker Hub Downloads: Fetched from Docker Hub v2 API
Slack Community Members: Fetched via Slack API (conversation info)
Stats are written to static/stats.json during build and used site-wide

New Components & Files
✨ src/utils/formatShortNumber.ts — Utility to format large numbers (e.g., 2.6M+, 8.7K+)
📄 static/stats.json — Generated at build time with live statistics

Updated Components
CommunityPage/Hero — Displays GitHub stars, downloads, Slack members dynamically
NewLandingPage/OpenSource — Shows live star count and community members
NewLandingPage/TrustedBy — Displays live download count in marquee stats
Navigation — Removed @ts-ignore comment, cleaner imports

CI/CD Updates
Added 3 new environment variables to both workflows:
SLACK_BOT_TOKEN — For fetching Slack channel member count
SLACK_CHANNEL_ID — Target Slack channel ID
RP_GITHUB_STATS— For higher API rate limits on GitHub (optional fallback to public API)

Key Features
✅ Graceful fallbacks if APIs are down or env vars missing
✅ Type-safe TypeScript implementation
✅ No performance impact (stats fetched at build time)
✅ Proper error handling & logging ([stats] prefix)


# ReportPortal Website – Token & Secret Setup Instructions

## 1. Slack Bot User OAuth Token (`SLACK_BOT_TOKEN`)

**Steps:**
1. Go to [Slack API: Your Apps](https://api.slack.com/apps).
2. Click **Create New App** → **From scratch**.
3. Name your app (e.g., `ReportPortal Stats`) and select the `epmrpp.reportportal.io` workspace.
4. In the app settings, go to **OAuth & Permissions**.
5. Scroll to **Scopes** → **Bot Token Scopes** → click **Add an OAuth Scope**.
6. Select and add `channels:read`.
7. Go to the **OAuth Tokens** section and click **Install to Workspace**.
8. Allow the app to access Slack when prompted.
9. After installation, you’ll see the **Bot User OAuth Token** (starts with `xoxb-`) in the **OAuth Tokens for Your Workspace** section.
10. **Add this token as a repository secret** in GitHub named `SLACK_BOT_TOKEN`.  
    _For local development or manual builds, add it to your `.env.production` file as well:_
    ```env
    SLACK_BOT_TOKEN=xoxb-your-token-here
    ```

---

## 2. Slack Channel ID (`SLACK_CHANNEL_ID`)

**Steps:**
1. In the Slack ReportPortal workspace, go to the desired channel (e.g., `#general`).
2. Click the three dots (•••) in the top right corner.
3. Select **Channel details**.
4. In the modal that opens, scroll to the bottom to find the **Channel ID** (e.g., `C0XXXXXXXX`).
5. **Add this Channel ID as a repository secret** in GitHub named `SLACK_CHANNEL_ID`.  
   _For local development or manual builds, add it to your `.env.production` file as well:_
    ```env
    SLACK_CHANNEL_ID=C01234ABCDE
    ```

---

## 3. GitHub Personal Access Token (`RP_GITHUB_STATS`)

**Steps:**
1. Go to [GitHub Personal Access Tokens](https://github.com/settings/tokens/new).
2. Add a note name for your token (e.g., `ReportPortal Stats`).
3. You can leave all checkboxes (scopes) empty—no additional permissions are required.
4. Click **Generate token**.
5. Copy the generated token (it will start with `ghp_`).
6. **Add this token as a repository secret** in GitHub named `STATS_GITHUB_TOKEN` (or the name your workflow expects).  
   _For local development or manual builds, add it to your `.env.production` file as `RP_GITHUB_STATS`:_
    ```env
    RP_GITHUB_STATS=ghp_your_token_here
    ```

---

## 4. Where to Add the Values

- **For CI/CD (GitHub Actions):**  
  Add all values as **repository secrets** in your GitHub repository under  
  **Settings → Secrets and variables → Actions**.
- **For local development or manual builds:**  
  Add all values to your local `.env.production` file.


---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **New Features**
  * Community pages now display dynamically updated GitHub stars, downloads, forks, and member counts.
  * Landing-page statistics include current download and community figures.
  * Added consistent short-number formatting, such as `K+` and `M+`.
  * Community join messaging reflects the latest member count.
* **Bug Fixes**
  * Improved fallback handling keeps statistics available when external data cannot be retrieved.
  * Updated statistic labels and values for clearer, more accurate presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->