### PR TITLE
EPMRPP-116316 || Pages have more than one H1 tag

### DIFF
--- a/src/components/Faq/Faq.scss
+++ b/src/components/Faq/Faq.scss
@@ -30,7 +30,7 @@ $mobile-horizontal-padding: 16px;
   &__heading {
     text-align: center;
 
-    h1 {
+    h2 {
       @include features-title();
 
       max-width: 952px;

--- a/src/components/Faq/Faq.tsx
+++ b/src/components/Faq/Faq.tsx
@@ -25,7 +25,7 @@ export const Faq: FC<FaqProps> = ({
 }) => (
   <div className={classNames('container', getBlocksWith())}>
     <div className={getBlocksWith('__heading')}>
-      <h1 id={titleId}>Frequently asked questions</h1>
+      <h2 id={titleId}>Frequently asked questions</h2>
     </div>
     <div className={getBlocksWith('__content')}>
       <Collapse


### PR DESCRIPTION
### PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, `master` for release/hotfix)?
* [ ] Have you followed the guidelines in our [Dev Guide](../#readme)
* [ ] Have you run prettier (`npm run format`)?
* [ ] Have you checked that the build output looks according to design (screen, mobile, desktop) in Figma (`npm run serve`)?

## Description
changed the tag for FAQ section from h1 to h2 to avoid more than one h1 tag in one page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Updated the FAQ section heading to use a second-level heading, improving page heading hierarchy while preserving its text and identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->