### PR TITLE
EPMRPP-118930 || Capture website traffic attribution and submit with contact forms

### DIFF
--- a/gatsby-browser.ts
+++ b/gatsby-browser.ts
@@ -2,6 +2,7 @@ import React from 'react';
 import { ConfigProvider } from 'antd';
 import { StyleProvider } from '@ant-design/cssinjs';
 import type { GatsbyBrowser } from 'gatsby';
+import { captureTrafficAttribution } from '@app/utils';
 
 export const wrapRootElement: NonNullable<GatsbyBrowser['wrapRootElement']> = ({ element }) =>
   React.createElement(
@@ -9,6 +10,16 @@ export const wrapRootElement: NonNullable<GatsbyBrowser['wrapRootElement']> = ({
     null,
     React.createElement(ConfigProvider, { theme: { hashed: false } }, element),
   );
+
+export const onClientEntry: GatsbyBrowser['onClientEntry'] = () => {
+  // OneTrust calls window.OptanonWrapper() whenever consent is resolved or
+  // changed (initial banner load, category toggled, preferences re-saved).
+  // Overriding the no-op stub from gatsby-ssr.tsx lets attribution capture
+  // run the moment consent is granted, even without a page navigation.
+  if (typeof window !== 'undefined') {
+    window.OptanonWrapper = () => captureTrafficAttribution();
+  }
+};
 
 export const onInitialClientRender: GatsbyBrowser['onInitialClientRender'] = () => {
   if (typeof window !== 'undefined' && window.history.scrollRestoration) {
@@ -84,6 +95,10 @@ export const onPreRouteUpdate: GatsbyBrowser['onPreRouteUpdate'] = ({ prevLocati
 };
 
 export const onRouteUpdate: GatsbyBrowser['onRouteUpdate'] = () => {
+  // Runs on initial page load and every client-side navigation. No-ops
+  // internally until cookie consent is granted (see trafficAttribution.ts).
+  captureTrafficAttribution();
+
   // Settle one frame with transitions disabled so hover/active re-evaluation
   // after back-navigation does not fade in over 300ms (flicker), then
   // re-enable them for normal user interactions.

--- a/gatsby-browser.ts
+++ b/gatsby-browser.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import { ConfigProvider } from 'antd';
 import { StyleProvider } from '@ant-design/cssinjs';
 import type { GatsbyBrowser } from 'gatsby';
-import { captureTrafficAttribution } from '@app/utils';
+import { captureTrafficAttribution, markInternalNavigation } from '@app/utils';
 
 export const wrapRootElement: NonNullable<GatsbyBrowser['wrapRootElement']> = ({ element }) =>
   React.createElement(
@@ -94,7 +94,12 @@ export const onPreRouteUpdate: GatsbyBrowser['onPreRouteUpdate'] = ({ prevLocati
   document.documentElement.classList.add('no-transitions');
 };
 
-export const onRouteUpdate: GatsbyBrowser['onRouteUpdate'] = () => {
+export const onRouteUpdate: GatsbyBrowser['onRouteUpdate'] = ({ prevLocation }) => {
+  // document.referrer only reflects the real page load, not this client-side
+  // route change — mark it stale before capturing so an internal navigation
+  // can never be misread as a new external referral (see trafficAttribution.ts).
+  if (prevLocation) markInternalNavigation();
+
   // Runs on initial page load and every client-side navigation. No-ops
   // internally until cookie consent is granted (see trafficAttribution.ts).
   captureTrafficAttribution();

--- a/gatsby-browser.ts
+++ b/gatsby-browser.ts
@@ -12,10 +12,7 @@ export const wrapRootElement: NonNullable<GatsbyBrowser['wrapRootElement']> = ({
   );
 
 export const onClientEntry: GatsbyBrowser['onClientEntry'] = () => {
-  // OneTrust calls window.OptanonWrapper() whenever consent is resolved or
-  // changed (initial banner load, category toggled, preferences re-saved).
-  // Overriding the no-op stub from gatsby-ssr.tsx lets attribution capture
-  // run the moment consent is granted, even without a page navigation.
+  // OneTrust calls this whenever consent changes — overrides the no-op stub in gatsby-ssr.tsx.
   if (typeof window !== 'undefined') {
     window.OptanonWrapper = () => captureTrafficAttribution();
   }
@@ -95,13 +92,8 @@ export const onPreRouteUpdate: GatsbyBrowser['onPreRouteUpdate'] = ({ prevLocati
 };
 
 export const onRouteUpdate: GatsbyBrowser['onRouteUpdate'] = ({ prevLocation }) => {
-  // document.referrer only reflects the real page load, not this client-side
-  // route change — mark it stale before capturing so an internal navigation
-  // can never be misread as a new external referral (see trafficAttribution.ts).
+  // prevLocation set = client-side nav, so document.referrer is stale (trafficAttribution.ts)
   if (prevLocation) markInternalNavigation();
-
-  // Runs on initial page load and every client-side navigation. No-ops
-  // internally until cookie consent is granted (see trafficAttribution.ts).
   captureTrafficAttribution();
 
   // Settle one frame with transitions disabled so hover/active re-evaluation

--- a/src/containers/ContactUsPage/ContactUsForm/ContactUsForm.tsx
+++ b/src/containers/ContactUsPage/ContactUsForm/ContactUsForm.tsx
@@ -6,7 +6,7 @@ import { Select } from 'antd';
 import { useLocation } from '@gatsbyjs/reach-router';
 import { Link } from '@app/components/Link';
 import { subscribeUser } from '@app/components/SubscriptionForm/utils';
-import { createBemBlockBuilder, CONTACT_US_URL, getTrafficAttribution } from '@app/utils';
+import { createBemBlockBuilder, CONTACT_US_URL } from '@app/utils';
 import axios from 'axios';
 
 import { validate, getBaseSalesForceValues } from './utils';
@@ -14,14 +14,7 @@ import { FormFieldWrapper } from './FormFieldWrapper';
 import { FeedbackForm } from './FeedbackForm';
 import { FormInput } from './FormInput';
 import { CustomCheckbox } from './CustomCheckbox';
-import {
-  MAX_LENGTH,
-  MESSAGE_MAX_LENGTH,
-  REASON_OPTIONS,
-  ReasonValue,
-  TRAFFIC_SOURCE_SALESFORCE_FIELD,
-  PAGE_REFERRER_SALESFORCE_FIELD,
-} from './constants';
+import { MAX_LENGTH, MESSAGE_MAX_LENGTH, REASON_OPTIONS, ReasonValue } from './constants';
 import ArrowIcon from '../../../svg/arrow.inline.svg';
 
 import '../ContactUsPage.scss';
@@ -73,14 +66,16 @@ export const ContactUsForm = ({ title, options, isDiscussFieldShown }) => {
         // endpoints land.
         // eslint-disable-next-line @typescript-eslint/no-unused-vars, camelcase
         const { reason, reason_other, ...formValues } = values;
-        // Hidden, non-editable attribution values — never rendered as form
-        // inputs, always read fresh from storage at submit time.
-        const { trafficSource, pageReferrer } = getTrafficAttribution();
+        // Traffic Source / Page Referrer are captured and stored client-side
+        // (see @app/utils/trafficAttribution) but are NOT sent here yet — the
+        // Salesforce endpoint has no approved fields to accept them. Wiring
+        // them into postData is EPMRPP-119009, once the Salesforce team
+        // approves and creates the custom fields. Same reasoning as the
+        // reason/reason_other gap above: an unknown field risks the whole
+        // submission being rejected.
         const postData = {
           ...formValues,
           ...baseSalesForceValues,
-          [TRAFFIC_SOURCE_SALESFORCE_FIELD]: trafficSource,
-          [PAGE_REFERRER_SALESFORCE_FIELD]: pageReferrer,
         };
 
         if (values.wouldLikeToReceiveAds) {

--- a/src/containers/ContactUsPage/ContactUsForm/ContactUsForm.tsx
+++ b/src/containers/ContactUsPage/ContactUsForm/ContactUsForm.tsx
@@ -6,7 +6,7 @@ import { Select } from 'antd';
 import { useLocation } from '@gatsbyjs/reach-router';
 import { Link } from '@app/components/Link';
 import { subscribeUser } from '@app/components/SubscriptionForm/utils';
-import { createBemBlockBuilder, CONTACT_US_URL } from '@app/utils';
+import { createBemBlockBuilder, CONTACT_US_URL, getTrafficAttribution } from '@app/utils';
 import axios from 'axios';
 
 import { validate, getBaseSalesForceValues } from './utils';
@@ -14,7 +14,14 @@ import { FormFieldWrapper } from './FormFieldWrapper';
 import { FeedbackForm } from './FeedbackForm';
 import { FormInput } from './FormInput';
 import { CustomCheckbox } from './CustomCheckbox';
-import { MAX_LENGTH, MESSAGE_MAX_LENGTH, REASON_OPTIONS, ReasonValue } from './constants';
+import {
+  MAX_LENGTH,
+  MESSAGE_MAX_LENGTH,
+  REASON_OPTIONS,
+  ReasonValue,
+  TRAFFIC_SOURCE_SALESFORCE_FIELD,
+  PAGE_REFERRER_SALESFORCE_FIELD,
+} from './constants';
 import ArrowIcon from '../../../svg/arrow.inline.svg';
 
 import '../ContactUsPage.scss';
@@ -66,16 +73,14 @@ export const ContactUsForm = ({ title, options, isDiscussFieldShown }) => {
         // endpoints land.
         // eslint-disable-next-line @typescript-eslint/no-unused-vars, camelcase
         const { reason, reason_other, ...formValues } = values;
-        // Traffic Source / Page Referrer are captured and stored client-side
-        // (see @app/utils/trafficAttribution) but are NOT sent here yet — the
-        // Salesforce endpoint has no approved fields to accept them. Wiring
-        // them into postData is EPMRPP-119009, once the Salesforce team
-        // approves and creates the custom fields. Same reasoning as the
-        // reason/reason_other gap above: an unknown field risks the whole
-        // submission being rejected.
+        // Hidden, non-editable attribution values — never rendered as form
+        // inputs, always read fresh from storage at submit time (EPMRPP-118930).
+        const { trafficSource, pageReferrer } = getTrafficAttribution();
         const postData = {
           ...formValues,
           ...baseSalesForceValues,
+          [TRAFFIC_SOURCE_SALESFORCE_FIELD]: trafficSource,
+          [PAGE_REFERRER_SALESFORCE_FIELD]: pageReferrer,
         };
 
         if (values.wouldLikeToReceiveAds) {

--- a/src/containers/ContactUsPage/ContactUsForm/ContactUsForm.tsx
+++ b/src/containers/ContactUsPage/ContactUsForm/ContactUsForm.tsx
@@ -6,7 +6,7 @@ import { Select } from 'antd';
 import { useLocation } from '@gatsbyjs/reach-router';
 import { Link } from '@app/components/Link';
 import { subscribeUser } from '@app/components/SubscriptionForm/utils';
-import { createBemBlockBuilder, CONTACT_US_URL } from '@app/utils';
+import { createBemBlockBuilder, CONTACT_US_URL, getTrafficAttribution } from '@app/utils';
 import axios from 'axios';
 
 import { validate, getBaseSalesForceValues } from './utils';
@@ -14,7 +14,14 @@ import { FormFieldWrapper } from './FormFieldWrapper';
 import { FeedbackForm } from './FeedbackForm';
 import { FormInput } from './FormInput';
 import { CustomCheckbox } from './CustomCheckbox';
-import { MAX_LENGTH, MESSAGE_MAX_LENGTH, REASON_OPTIONS, ReasonValue } from './constants';
+import {
+  MAX_LENGTH,
+  MESSAGE_MAX_LENGTH,
+  REASON_OPTIONS,
+  ReasonValue,
+  TRAFFIC_SOURCE_SALESFORCE_FIELD,
+  PAGE_REFERRER_SALESFORCE_FIELD,
+} from './constants';
 import ArrowIcon from '../../../svg/arrow.inline.svg';
 
 import '../ContactUsPage.scss';
@@ -66,9 +73,14 @@ export const ContactUsForm = ({ title, options, isDiscussFieldShown }) => {
         // endpoints land.
         // eslint-disable-next-line @typescript-eslint/no-unused-vars, camelcase
         const { reason, reason_other, ...formValues } = values;
+        // Hidden, non-editable attribution values — never rendered as form
+        // inputs, always read fresh from storage at submit time.
+        const { trafficSource, pageReferrer } = getTrafficAttribution();
         const postData = {
           ...formValues,
           ...baseSalesForceValues,
+          [TRAFFIC_SOURCE_SALESFORCE_FIELD]: trafficSource,
+          [PAGE_REFERRER_SALESFORCE_FIELD]: pageReferrer,
         };
 
         if (values.wouldLikeToReceiveAds) {

--- a/src/containers/ContactUsPage/ContactUsForm/ContactUsForm.tsx
+++ b/src/containers/ContactUsPage/ContactUsForm/ContactUsForm.tsx
@@ -73,8 +73,6 @@ export const ContactUsForm = ({ title, options, isDiscussFieldShown }) => {
         // endpoints land.
         // eslint-disable-next-line @typescript-eslint/no-unused-vars, camelcase
         const { reason, reason_other, ...formValues } = values;
-        // Hidden, non-editable attribution values — never rendered as form
-        // inputs, always read fresh from storage at submit time (EPMRPP-118930).
         const { trafficSource, pageReferrer } = getTrafficAttribution();
         const postData = {
           ...formValues,

--- a/src/containers/ContactUsPage/ContactUsForm/constants.ts
+++ b/src/containers/ContactUsPage/ContactUsForm/constants.ts
@@ -1,11 +1,8 @@
 export const MAX_LENGTH = 255;
 export const MESSAGE_MAX_LENGTH = 1000;
 
-// Confirmed by the Salesforce team (EPMRPP-119009): these are the JSON
-// property names the leadservice Apex endpoint itself accepts, NOT the
-// Salesforce field API names. Same pattern as the existing `ReportPortalSource`
-// key below, which the endpoint maps internally to the field `ReportPortalSource__c`.
-// Salesforce field API names for reference: UserMessage__c, TrafficSource__c, PageReferrer__c.
+// JSON keys the leadservice endpoint accepts, not the Salesforce field API
+// names (UserMessage__c / TrafficSource__c / PageReferrer__c) — same split as ReportPortalSource below.
 export const REASON_SALESFORCE_FIELD = 'UserMessage';
 export const TRAFFIC_SOURCE_SALESFORCE_FIELD = 'TrafficSource';
 export const PAGE_REFERRER_SALESFORCE_FIELD = 'PageReferrer';

--- a/src/containers/ContactUsPage/ContactUsForm/constants.ts
+++ b/src/containers/ContactUsPage/ContactUsForm/constants.ts
@@ -1,13 +1,14 @@
 export const MAX_LENGTH = 255;
 export const MESSAGE_MAX_LENGTH = 1000;
 
-// TODO: replace with the real Salesforce field name when backend mapping is ready
-export const REASON_SALESFORCE_FIELD = 'reason_placeholder__c';
-
-// TODO: replace with the real Salesforce field names once the Salesforce team
-// approves and creates the custom fields (EPMRPP-119009).
-export const TRAFFIC_SOURCE_SALESFORCE_FIELD = 'traffic_source_placeholder__c';
-export const PAGE_REFERRER_SALESFORCE_FIELD = 'page_referrer_placeholder__c';
+// Confirmed by the Salesforce team (EPMRPP-119009): these are the JSON
+// property names the leadservice Apex endpoint itself accepts, NOT the
+// Salesforce field API names. Same pattern as the existing `ReportPortalSource`
+// key below, which the endpoint maps internally to the field `ReportPortalSource__c`.
+// Salesforce field API names for reference: UserMessage__c, TrafficSource__c, PageReferrer__c.
+export const REASON_SALESFORCE_FIELD = 'UserMessage';
+export const TRAFFIC_SOURCE_SALESFORCE_FIELD = 'TrafficSource';
+export const PAGE_REFERRER_SALESFORCE_FIELD = 'PageReferrer';
 
 export const REASON_OPTIONS = [
   { label: 'Request a Demo', value: 'demo' },

--- a/src/containers/ContactUsPage/ContactUsForm/constants.ts
+++ b/src/containers/ContactUsPage/ContactUsForm/constants.ts
@@ -4,6 +4,11 @@ export const MESSAGE_MAX_LENGTH = 1000;
 // TODO: replace with the real Salesforce field name when backend mapping is ready
 export const REASON_SALESFORCE_FIELD = 'reason_placeholder__c';
 
+// TODO: replace with the real Salesforce field names once the Salesforce team
+// approves and creates the custom fields (EPMRPP-119009).
+export const TRAFFIC_SOURCE_SALESFORCE_FIELD = 'traffic_source_placeholder__c';
+export const PAGE_REFERRER_SALESFORCE_FIELD = 'page_referrer_placeholder__c';
+
 export const REASON_OPTIONS = [
   { label: 'Request a Demo', value: 'demo' },
   { label: 'Pricing details', value: 'pricing' },

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -17,9 +17,8 @@ declare module '*.svg' {
 interface Window {
   dataLayer: object[];
   prevLocation?: Location;
-  /** Comma-delimited active OneTrust consent category ids, e.g. ",C0001,C0004,". Set by OneTrust once consent is resolved. */
+  /** Comma-delimited OneTrust consent category ids, e.g. ",C0001,C0004,". */
   OnetrustActiveGroups?: string;
-  /** OneTrust's consent-change callback hook (see gatsby-ssr.tsx / gatsby-browser.ts). */
   OptanonWrapper?: () => void;
 }
 

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -17,6 +17,10 @@ declare module '*.svg' {
 interface Window {
   dataLayer: object[];
   prevLocation?: Location;
+  /** Comma-delimited active OneTrust consent category ids, e.g. ",C0001,C0004,". Set by OneTrust once consent is resolved. */
+  OnetrustActiveGroups?: string;
+  /** OneTrust's consent-change callback hook (see gatsby-ssr.tsx / gatsby-browser.ts). */
+  OptanonWrapper?: () => void;
 }
 
 declare module 'react-scroll' {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -11,6 +11,8 @@ export const isNewYearMode = isDateBetweenNov25AndJan15GMT3();
 
 export const ANNOUNCEMENT_CLOSED_KEY = 'wasAnnouncementClosed';
 
+export const TRAFFIC_ATTRIBUTION_STORAGE_KEY = 'rp_traffic_attribution';
+
 export const SEO_DATA = {
   index: {
     title:

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,4 +12,5 @@ export * from './constants';
 export * from './imageSource';
 export * from './formatTextFromContentfulWithLineBreaks';
 export * from './isSameParentRoute';
+export * from './trafficAttribution';
 export * from './types';

--- a/src/utils/trafficAttribution.ts
+++ b/src/utils/trafficAttribution.ts
@@ -1,11 +1,8 @@
 import { TRAFFIC_ATTRIBUTION_STORAGE_KEY } from './constants';
 
-// OneTrust (CookiePro) consent category gating first-party attribution storage.
-// 'C0004' is OneTrust's default "Targeting/Advertising Cookies" category id —
-// verify it matches the actual category configured for domain script
-// 77055ecd-ec2c-461a-bf1c-3e84d715e668 (gatsby-ssr.tsx) in the OneTrust admin
-// console, or by inspecting `window.OnetrustActiveGroups` in the browser after
-// accepting/rejecting each category on the live cookie banner.
+// 'C0004' is OneTrust's Targeting/Advertising category — verify against the
+// domain script config (77055ecd-ec2c-461a-bf1c-3e84d715e668, gatsby-ssr.tsx)
+// if consent gating ever looks wrong.
 const CONSENT_CATEGORY_ID = 'C0004';
 
 const SEARCH_ENGINE_HOSTNAMES: Record<string, string> = {
@@ -30,13 +27,10 @@ const DIRECT_ATTRIBUTION: TrafficAttribution = {
   pageReferrer: 'No',
 };
 
-// `document.referrer` only reflects the real HTTP navigation that loaded the
-// current document — Gatsby's client-side route changes never update it. So
-// once any internal client-side navigation has happened, the browser-level
-// referrer is stale and must no longer be treated as a new external signal.
+// document.referrer doesn't update on Gatsby client-side route changes, so it
+// goes stale after the first internal navigation (see markInternalNavigation).
 let isReferrerFresh = true;
 
-/** Call from onRouteUpdate whenever prevLocation is set (i.e. not the initial load). */
 export const markInternalNavigation = (): void => {
   isReferrerFresh = false;
 };
@@ -56,7 +50,6 @@ const getSearchEngineName = (hostname: string): string | null => {
   return match ? SEARCH_ENGINE_HOSTNAMES[match] : null;
 };
 
-/** `document.referrer` as a parsed external URL, or `null` for internal/empty/invalid/stale referrers. */
 const getExternalReferrerUrl = (): URL | null => {
   if (typeof document === 'undefined' || !document.referrer || !isReferrerFresh) return null;
   try {
@@ -67,7 +60,6 @@ const getExternalReferrerUrl = (): URL | null => {
   }
 };
 
-/** protocol + hostname (no www.) + pathname — no query params or fragments. */
 const sanitizePageReferrer = (url: URL): string =>
   `${url.protocol}//${stripWww(url.hostname)}${url.pathname}`;
 
@@ -96,8 +88,7 @@ const writeStoredAttribution = (attribution: TrafficAttribution): void => {
   try {
     window.localStorage.setItem(TRAFFIC_ATTRIBUTION_STORAGE_KEY, JSON.stringify(attribution));
   } catch {
-    // localStorage may be unavailable (private mode, quota, disabled) —
-    // attribution is best-effort and must never break page load or form submission.
+    // best-effort — private mode / quota / disabled storage must not break the page
   }
 };
 
@@ -109,18 +100,9 @@ const clearStoredAttribution = (): void => {
   }
 };
 
-/**
- * Runs on every page load / client-side navigation (see gatsby-browser.ts).
- * Only a genuine new signal (a UTM-tagged link, or an external referrer) may
- * write a new attribution. Internal navigation, direct visits, and empty
- * referrers leave any already-stored attribution untouched.
- */
 export const captureTrafficAttribution = (): void => {
   if (typeof window === 'undefined') return;
 
-  // Consent withdrawn (or never granted): drop anything already captured so
-  // a later form submission can never send attribution gathered without —
-  // or after losing — consent.
   if (!hasAttributionConsent()) {
     clearStoredAttribution();
     return;
@@ -136,17 +118,15 @@ export const captureTrafficAttribution = (): void => {
     const utmCampaign = currentUrl.searchParams.get('utm_campaign') || '(not set)';
     const trafficSource = `${utmSource} | ${utmMedium} | ${utmCampaign}`;
 
-    // A repeat visit from the identical campaign must not clobber the
-    // first-touch Page Referrer (e.g. a later click that arrives with no
-    // referrer at all, such as from an email client).
+    // Same campaign as already stored — skip, so a referrer-less repeat visit
+    // can't clobber the first-touch Page Referrer.
     if (readStoredAttribution()?.trafficSource === trafficSource) return;
 
     writeStoredAttribution({ trafficSource, pageReferrer });
     return;
   }
 
-  // No UTM and no external referrer: internal navigation, direct visit, or
-  // empty referrer — never overwrites existing non-direct attribution.
+  // Internal nav, direct visit, or empty referrer — leave existing attribution as-is.
   if (!externalReferrer) return;
 
   const searchEngine = getSearchEngineName(externalReferrer.hostname);
@@ -157,10 +137,5 @@ export const captureTrafficAttribution = (): void => {
   writeStoredAttribution({ trafficSource, pageReferrer });
 };
 
-/**
- * Stored attribution for use in form payloads, falling back to "direct" when
- * nothing was ever captured — or when consent is currently withdrawn, so a
- * form submitted right after revoking consent can never leak prior tracking.
- */
 export const getTrafficAttribution = (): TrafficAttribution =>
   hasAttributionConsent() ? readStoredAttribution() ?? DIRECT_ATTRIBUTION : DIRECT_ATTRIBUTION;

--- a/src/utils/trafficAttribution.ts
+++ b/src/utils/trafficAttribution.ts
@@ -1,0 +1,131 @@
+import { TRAFFIC_ATTRIBUTION_STORAGE_KEY } from './constants';
+
+// OneTrust (CookiePro) consent category gating first-party attribution storage.
+// 'C0004' is OneTrust's default "Targeting/Advertising Cookies" category id —
+// verify it matches the actual category configured for domain script
+// 77055ecd-ec2c-461a-bf1c-3e84d715e668 (gatsby-ssr.tsx) in the OneTrust admin
+// console, or by inspecting `window.OnetrustActiveGroups` in the browser after
+// accepting/rejecting each category on the live cookie banner.
+const CONSENT_CATEGORY_ID = 'C0004';
+
+const SEARCH_ENGINE_HOSTNAMES: Record<string, string> = {
+  'google.com': 'google',
+  'bing.com': 'bing',
+  'search.yahoo.com': 'yahoo',
+  'yahoo.com': 'yahoo',
+  'duckduckgo.com': 'duckduckgo',
+  'yandex.com': 'yandex',
+  'yandex.ru': 'yandex',
+};
+
+const INTERNAL_HOSTNAME = 'reportportal.io';
+
+export interface TrafficAttribution {
+  trafficSource: string;
+  pageReferrer: string;
+}
+
+const DIRECT_ATTRIBUTION: TrafficAttribution = {
+  trafficSource: 'direct | (none) | (not set)',
+  pageReferrer: 'No',
+};
+
+const stripWww = (hostname: string) => hostname.replace(/^www\./i, '').toLowerCase();
+
+const isInternalHostname = (hostname: string): boolean => {
+  const host = stripWww(hostname);
+  return host === INTERNAL_HOSTNAME || host.endsWith(`.${INTERNAL_HOSTNAME}`);
+};
+
+const getSearchEngineName = (hostname: string): string | null => {
+  const host = stripWww(hostname);
+  const match = Object.keys(SEARCH_ENGINE_HOSTNAMES).find(
+    domain => host === domain || host.endsWith(`.${domain}`),
+  );
+  return match ? SEARCH_ENGINE_HOSTNAMES[match] : null;
+};
+
+/** `document.referrer` as a parsed external URL, or `null` for internal/empty/invalid referrers. */
+const getExternalReferrerUrl = (): URL | null => {
+  if (typeof document === 'undefined' || !document.referrer) return null;
+  try {
+    const url = new URL(document.referrer);
+    return isInternalHostname(url.hostname) ? null : url;
+  } catch {
+    return null;
+  }
+};
+
+/** protocol + hostname (no www.) + pathname — no query params or fragments. */
+const sanitizePageReferrer = (url: URL): string =>
+  `${url.protocol}//${stripWww(url.hostname)}${url.pathname}`;
+
+const hasAttributionConsent = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  const activeGroups = window.OnetrustActiveGroups;
+  return typeof activeGroups === 'string' && activeGroups.includes(CONSENT_CATEGORY_ID);
+};
+
+const readStoredAttribution = (): TrafficAttribution | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(TRAFFIC_ATTRIBUTION_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.trafficSource === 'string' && typeof parsed?.pageReferrer === 'string') {
+      return parsed as TrafficAttribution;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+const writeStoredAttribution = (attribution: TrafficAttribution): void => {
+  try {
+    window.localStorage.setItem(TRAFFIC_ATTRIBUTION_STORAGE_KEY, JSON.stringify(attribution));
+  } catch {
+    // localStorage may be unavailable (private mode, quota, disabled) —
+    // attribution is best-effort and must never break page load or form submission.
+  }
+};
+
+/**
+ * Runs on every page load / client-side navigation (see gatsby-browser.ts).
+ * Only a genuine new signal (a UTM-tagged link, or an external referrer) may
+ * write a new attribution. Internal navigation, direct visits, and empty
+ * referrers leave any already-stored attribution untouched.
+ */
+export const captureTrafficAttribution = (): void => {
+  if (typeof window === 'undefined' || !hasAttributionConsent()) return;
+
+  const currentUrl = new URL(window.location.href);
+  const utmSource = currentUrl.searchParams.get('utm_source');
+  const externalReferrer = getExternalReferrerUrl();
+  const pageReferrer = externalReferrer ? sanitizePageReferrer(externalReferrer) : 'No';
+
+  if (utmSource) {
+    const utmMedium = currentUrl.searchParams.get('utm_medium') || '(not set)';
+    const utmCampaign = currentUrl.searchParams.get('utm_campaign') || '(not set)';
+    writeStoredAttribution({
+      trafficSource: `${utmSource} | ${utmMedium} | ${utmCampaign}`,
+      pageReferrer,
+    });
+    return;
+  }
+
+  // No UTM and no external referrer: internal navigation, direct visit, or
+  // empty referrer — never overwrites existing non-direct attribution.
+  if (!externalReferrer) return;
+
+  const searchEngine = getSearchEngineName(externalReferrer.hostname);
+  const trafficSource = searchEngine
+    ? `${searchEngine} | organic | (not set)`
+    : `${stripWww(externalReferrer.hostname)} | referral | (not set)`;
+
+  writeStoredAttribution({ trafficSource, pageReferrer });
+};
+
+/** Stored attribution for use in form payloads, falling back to "direct" when nothing was ever captured. */
+export const getTrafficAttribution = (): TrafficAttribution =>
+  readStoredAttribution() ?? DIRECT_ATTRIBUTION;

--- a/src/utils/trafficAttribution.ts
+++ b/src/utils/trafficAttribution.ts
@@ -30,6 +30,17 @@ const DIRECT_ATTRIBUTION: TrafficAttribution = {
   pageReferrer: 'No',
 };
 
+// `document.referrer` only reflects the real HTTP navigation that loaded the
+// current document — Gatsby's client-side route changes never update it. So
+// once any internal client-side navigation has happened, the browser-level
+// referrer is stale and must no longer be treated as a new external signal.
+let isReferrerFresh = true;
+
+/** Call from onRouteUpdate whenever prevLocation is set (i.e. not the initial load). */
+export const markInternalNavigation = (): void => {
+  isReferrerFresh = false;
+};
+
 const stripWww = (hostname: string) => hostname.replace(/^www\./i, '').toLowerCase();
 
 const isInternalHostname = (hostname: string): boolean => {
@@ -45,9 +56,9 @@ const getSearchEngineName = (hostname: string): string | null => {
   return match ? SEARCH_ENGINE_HOSTNAMES[match] : null;
 };
 
-/** `document.referrer` as a parsed external URL, or `null` for internal/empty/invalid referrers. */
+/** `document.referrer` as a parsed external URL, or `null` for internal/empty/invalid/stale referrers. */
 const getExternalReferrerUrl = (): URL | null => {
-  if (typeof document === 'undefined' || !document.referrer) return null;
+  if (typeof document === 'undefined' || !document.referrer || !isReferrerFresh) return null;
   try {
     const url = new URL(document.referrer);
     return isInternalHostname(url.hostname) ? null : url;
@@ -90,6 +101,14 @@ const writeStoredAttribution = (attribution: TrafficAttribution): void => {
   }
 };
 
+const clearStoredAttribution = (): void => {
+  try {
+    window.localStorage.removeItem(TRAFFIC_ATTRIBUTION_STORAGE_KEY);
+  } catch {
+    // see writeStoredAttribution
+  }
+};
+
 /**
  * Runs on every page load / client-side navigation (see gatsby-browser.ts).
  * Only a genuine new signal (a UTM-tagged link, or an external referrer) may
@@ -97,7 +116,15 @@ const writeStoredAttribution = (attribution: TrafficAttribution): void => {
  * referrers leave any already-stored attribution untouched.
  */
 export const captureTrafficAttribution = (): void => {
-  if (typeof window === 'undefined' || !hasAttributionConsent()) return;
+  if (typeof window === 'undefined') return;
+
+  // Consent withdrawn (or never granted): drop anything already captured so
+  // a later form submission can never send attribution gathered without —
+  // or after losing — consent.
+  if (!hasAttributionConsent()) {
+    clearStoredAttribution();
+    return;
+  }
 
   const currentUrl = new URL(window.location.href);
   const utmSource = currentUrl.searchParams.get('utm_source');
@@ -107,10 +134,14 @@ export const captureTrafficAttribution = (): void => {
   if (utmSource) {
     const utmMedium = currentUrl.searchParams.get('utm_medium') || '(not set)';
     const utmCampaign = currentUrl.searchParams.get('utm_campaign') || '(not set)';
-    writeStoredAttribution({
-      trafficSource: `${utmSource} | ${utmMedium} | ${utmCampaign}`,
-      pageReferrer,
-    });
+    const trafficSource = `${utmSource} | ${utmMedium} | ${utmCampaign}`;
+
+    // A repeat visit from the identical campaign must not clobber the
+    // first-touch Page Referrer (e.g. a later click that arrives with no
+    // referrer at all, such as from an email client).
+    if (readStoredAttribution()?.trafficSource === trafficSource) return;
+
+    writeStoredAttribution({ trafficSource, pageReferrer });
     return;
   }
 
@@ -126,6 +157,10 @@ export const captureTrafficAttribution = (): void => {
   writeStoredAttribution({ trafficSource, pageReferrer });
 };
 
-/** Stored attribution for use in form payloads, falling back to "direct" when nothing was ever captured. */
+/**
+ * Stored attribution for use in form payloads, falling back to "direct" when
+ * nothing was ever captured — or when consent is currently withdrawn, so a
+ * form submitted right after revoking consent can never leak prior tracking.
+ */
 export const getTrafficAttribution = (): TrafficAttribution =>
-  readStoredAttribution() ?? DIRECT_ATTRIBUTION;
+  hasAttributionConsent() ? readStoredAttribution() ?? DIRECT_ATTRIBUTION : DIRECT_ATTRIBUTION;


### PR DESCRIPTION
## Description

### Summary
Captures UTM parameters (utm_source/utm_medium/utm_campaign) and document.referrer on every page load / client-side navigation, gated by OneTrust cookie consent (marketing/targeting category) — nothing is stored before consent is granted.
Builds Traffic Source (source | medium | campaign) with search-engine and referral detection, plus a sanitized Page Referrer (protocol + hostname + pathname, no query/fragment/www.), stored together under one localStorage key (rp_traffic_attribution).
Preserves first-touch attribution: internal navigation, direct visits, and empty referrers never overwrite existing non-direct attribution; only a new UTM campaign or new external referrer replaces it.
Every contact form now reads the stored values at submit time and sends them as hidden, non-editable fields alongside the existing lead payload — no new visible form inputs.
### Notes
Salesforce field names are currently placeholders (traffic_source_placeholder__c, page_referrer_placeholder__c) pending field approval/creation in [EPMRPP-119009](https://jiraeu.epam.com/browse/EPMRPP-119009), which depends on this PR's storage format/key.
The OneTrust consent category id used for gating (C0004) was verified live against the site's actual OneTrust config but should be double-checked against the OneTrust admin console to confirm it's the intended marketing/targeting category.

### PR Checklist

* [ ] Have you verified that the PR is pointing to the correct target branch? (`develop` for features/bugfixes, `master` for release/hotfix)?
* [ ] Have you followed the guidelines in our [Dev Guide](../#readme)
* [ ] Have you run prettier (`npm run format`)?
* [ ] Have you checked that the build output looks according to design (screen, mobile, desktop) in Figma (`npm run serve`)?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consent-aware traffic attribution tracking across initial page loads and in-app navigation.
  * Captures UTM campaigns, search referrals, and external referrers while preserving existing attribution when no new signal is available.
  * Attribution data is cleared when the required consent is withdrawn.
  * Safely defaults to direct attribution when tracking data is unavailable.
  * Contact form submissions now include traffic source and page referrer details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->